### PR TITLE
api subcommand calls open 5e api

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -22,7 +22,8 @@ export const slack: APIGatewayProxyHandler = async (event, _ctx) => {
   /*first arg is token*/
   let [, slashCommand] = parseBody(event.body)
 
-  let body: string = getCommandHandler(slashCommand.command)(slashCommand)
+  let handler = getCommandHandler(slashCommand.command)
+  let body = await handler(slashCommand)
 
   try {
     return {

--- a/library/__tests__/get_command_handler.test.ts
+++ b/library/__tests__/get_command_handler.test.ts
@@ -1,7 +1,7 @@
 import get_command_handler from '../get_command_handler'
 import { Command } from '../command'
 import help from '../handlers/help'
-import api from '../handlers/api'
+import api from '../handlers/api/handler'
 
 describe('get_command_handler', () => {
   it('should handle api', () => {

--- a/library/get_command_handler.ts
+++ b/library/get_command_handler.ts
@@ -1,6 +1,6 @@
 import { Command } from './command'
 import helpHandler from './handlers/help'
-import apiHandler from './handlers/api'
+import apiHandler from './handlers/api/handler'
 
 export default (cmd: Command) => {
   switch (cmd) {

--- a/library/handlers/__tests__/api.test.ts
+++ b/library/handlers/__tests__/api.test.ts
@@ -1,8 +1,0 @@
-import api from '../api'
-import { defaultSlashCommand } from '../../../fixtures/slash_fixture'
-
-describe('api', () => {
-  it('should return', () => {
-    expect(api(defaultSlashCommand)).toMatchInlineSnapshot(`"api api spells"`)
-  })
-})

--- a/library/handlers/__tests__/help.test.ts
+++ b/library/handlers/__tests__/help.test.ts
@@ -1,10 +1,10 @@
-import help from "../help";
-import { defaultSlashCommand } from "../../../fixtures/slash_fixture";
+import help from '../help'
+import { defaultSlashCommand } from '../../../fixtures/slash_fixture'
 
-describe("help", () => {
-  it("should return", () => {
-    expect(help(defaultSlashCommand)).toMatchInlineSnapshot(
+describe('help', () => {
+  it('should return', async () => {
+    expect(await help(defaultSlashCommand)).toMatchInlineSnapshot(
       `"help api spells"`
-    );
-  });
-});
+    )
+  })
+})

--- a/library/handlers/api.ts
+++ b/library/handlers/api.ts
@@ -1,5 +1,0 @@
-import { SlashCommand } from '../slash_command'
-
-export default (cmd: SlashCommand) => {
-  return 'api ' + cmd.arguments
-}

--- a/library/handlers/api/__tests__/handler.test.ts
+++ b/library/handlers/api/__tests__/handler.test.ts
@@ -1,0 +1,24 @@
+import { defaultSlashCommand } from "../../../../fixtures/slash_fixture";
+import handler from "../handler";
+import axios from "axios";
+import { mocked } from "ts-jest/utils";
+
+jest.mock("axios");
+// here the whole foo var is mocked deeply
+const mockAxios = mocked(axios, true);
+
+describe("api handler", () => {
+  it("should handle happy", async () => {
+    mockAxios.get.mockImplementation(() =>
+      Promise.resolve({ data: { desc: "A fireball spell!" } })
+    );
+
+    let cmd = {
+      ...defaultSlashCommand,
+      text: "api spell fireball"
+    };
+    expect(await handler(cmd)).toMatchInlineSnapshot(
+      `"{\\"desc\\":\\"A fireball spell!\\"}"`
+    );
+  });
+});

--- a/library/handlers/api/__tests__/open_dnd_client.test.ts
+++ b/library/handlers/api/__tests__/open_dnd_client.test.ts
@@ -1,0 +1,8 @@
+import { getOpenDnDClient } from '../open_dnd_client'
+
+describe('Open Dnd Client', () => {
+  it('should make calls', () => {
+    let client = getOpenDnDClient()
+    expect(client.getInfo).not.toBeUndefined()
+  })
+})

--- a/library/handlers/api/__tests__/parse_arguments.test.ts
+++ b/library/handlers/api/__tests__/parse_arguments.test.ts
@@ -1,0 +1,8 @@
+import parse_arguments from '../parse_arguments'
+
+describe('parse arguments', () => {
+  it('should handle empty', () => {
+    let result = parse_arguments()
+    expect(result).toHaveLength(0)
+  })
+})

--- a/library/handlers/api/handler.ts
+++ b/library/handlers/api/handler.ts
@@ -1,0 +1,12 @@
+import { AxiosResponse } from 'axios'
+import { SlashCommand } from '../../slash_command'
+import { getOpenDnDClient } from './open_dnd_client'
+import parseArguments from './parse_arguments'
+
+export default async (cmd: SlashCommand) => {
+  let [subcmd, parameter] = parseArguments(cmd.arguments)
+  let client = getOpenDnDClient()
+  let resp: AxiosResponse = await client.getInfo(subcmd, parameter)
+
+  return JSON.stringify(resp.data)
+}

--- a/library/handlers/api/open_dnd_client.ts
+++ b/library/handlers/api/open_dnd_client.ts
@@ -1,0 +1,23 @@
+import axios from 'axios'
+
+const dndApi = (section: string) => `http://www.dnd5eapi.co/api/${section}`
+const dndApiSearch = (section: string) => (search: string) =>
+  `${dndApi(section)}?name=${search}`
+const dndApiItem = (section: string) => (item: string) =>
+  `${dndApi(section)}/${item}`
+
+const getInfo = (section, params?: string) => {
+  let endpoint = !params
+    ? dndApi(section)
+    : params.indexOf('?') != -1
+    ? dndApiSearch(section)(params.replace('?', ''))
+    : dndApiItem(section)(params)
+
+  return axios.get(endpoint)
+}
+
+export const getOpenDnDClient = () => {
+  return {
+    getInfo
+  }
+}

--- a/library/handlers/api/parse_arguments.ts
+++ b/library/handlers/api/parse_arguments.ts
@@ -1,0 +1,11 @@
+const ARGS_TOKENIZER = /(\w+)\s*(.*)/
+
+export default (params?: string) => {
+  if (!params || params.length === 0) {
+    return []
+  }
+
+  let [, section, sectionArgs] = ARGS_TOKENIZER.exec(params)
+
+  return [section, sectionArgs]
+}

--- a/library/handlers/help.ts
+++ b/library/handlers/help.ts
@@ -1,5 +1,5 @@
 import { SlashCommand } from '../slash_command'
 
-export default (cmd: SlashCommand) => {
+export default async (cmd: SlashCommand) => {
   return 'help ' + cmd.arguments
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@slack/events-api": "^2.3.2",
     "@slack/web-api": "^5.8.0",
+    "axios": "^0.19.2",
     "source-map-support": "^0.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
The API handler makes calls to the http://dnd5eapi.co endpoint.

Allows calls like:
`\waffle api classes`
`\waffle api races elf`
\waffle api spells ?acid`