### PR TITLE
ran eslint with --fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ jspm_packages
 
 # IntelliJ
 .idea
+
+# DynamoDB local
+.dynamodb

--- a/handler.ts
+++ b/handler.ts
@@ -21,7 +21,7 @@ export const hello: APIGatewayProxyHandler = async (event, _context) => {
 
 export const slack: APIGatewayProxyHandler = async (event, _ctx) => {
   try {
-    let tokenequality = verifySignature(event)
+    const tokenequality = verifySignature(event)
     if (tokenequality) {
       return {
         statusCode: 200,
@@ -35,7 +35,7 @@ export const slack: APIGatewayProxyHandler = async (event, _ctx) => {
     }
   }
 
-  let slashCommand = parseBody(event.body)
+  const slashCommand = parseBody(event.body)
   if (!slashCommand) {
     return {
       statusCode: 400,
@@ -43,7 +43,7 @@ export const slack: APIGatewayProxyHandler = async (event, _ctx) => {
     }
   }
 
-  let handler = getCommandHandler(slashCommand.command)
+  const handler = getCommandHandler(slashCommand.command)
 
   try {
     return {

--- a/library/__tests__/get_command_handler.test.ts
+++ b/library/__tests__/get_command_handler.test.ts
@@ -5,19 +5,19 @@ import api from '../handlers/api/handler'
 
 describe('get_command_handler', () => {
   it('should handle api', () => {
-    let handler = get_command_handler(Command['API'])
+    const handler = get_command_handler(Command['API'])
     expect(handler).toEqual(api)
   })
   it('should handle help', () => {
-    let handler = get_command_handler(Command['HELP'])
+    const handler = get_command_handler(Command['HELP'])
     expect(handler).toEqual(help)
   })
   it('should show help for noop', () => {
-    let handler = get_command_handler(Command['NOOP'])
+    const handler = get_command_handler(Command['NOOP'])
     expect(handler).toEqual(help)
   })
   it('should show help for undefined', () => {
-    let handler = get_command_handler(Command['???'])
+    const handler = get_command_handler(Command['???'])
     expect(handler).toEqual(help)
   })
 })

--- a/library/__tests__/parse_body.test.ts
+++ b/library/__tests__/parse_body.test.ts
@@ -4,13 +4,13 @@ import { stringify } from 'querystring'
 
 describe('parseBody', () => {
   it('should handle empty text', () => {
-    let cmd = stringify(slashCommand('/waffle'))
-    let slash = parseBody(cmd)
+    const cmd = stringify(slashCommand('/waffle'))
+    const slash = parseBody(cmd)
     expect(slash.command).toBe('NOOP')
   })
   it('should handle no argument help text', () => {
-    let cmd = stringify(slashCommand('/waffle', { text: 'help me' }))
-    let slash = parseBody(cmd)
+    const cmd = stringify(slashCommand('/waffle', { text: 'help me' }))
+    const slash = parseBody(cmd)
     expect(slash.command).toEqual('HELP')
   })
 })

--- a/library/__tests__/tokenize_text.test.ts
+++ b/library/__tests__/tokenize_text.test.ts
@@ -2,23 +2,23 @@ import tokenizeText from '../tokenize_text'
 
 describe('tokenizeText', () => {
   it('should return NOOP for empty text', () => {
-    let [cmd] = tokenizeText('')
+    const [cmd] = tokenizeText('')
     expect(cmd).toBe('NOOP')
   })
 
   it('should return NOOP for unknowns', () => {
-    let [cmd] = tokenizeText('break boys')
+    const [cmd] = tokenizeText('break boys')
     expect(cmd).toBe('NOOP')
   })
 
   it('should return HELP for help entry text', () => {
-    let [cmd, args] = tokenizeText('help api')
+    const [cmd, args] = tokenizeText('help api')
     expect(cmd).toBe('HELP')
     expect(args).toBe('api')
   })
 
   it('should return API for api spell text', () => {
-    let [cmd, args] = tokenizeText('api spell fireball')
+    const [cmd, args] = tokenizeText('api spell fireball')
     expect(cmd).toBe('API')
     expect(args).toBe('spell fireball')
   })

--- a/library/handlers/api/__tests__/handler.test.ts
+++ b/library/handlers/api/__tests__/handler.test.ts
@@ -13,7 +13,7 @@ describe("api handler", () => {
       Promise.resolve({ data: { desc: "A fireball spell!" } })
     );
 
-    let cmd = {
+    const cmd = {
       ...defaultSlashCommand,
       text: "api spell fireball"
     };

--- a/library/handlers/api/__tests__/open_dnd_client.test.ts
+++ b/library/handlers/api/__tests__/open_dnd_client.test.ts
@@ -2,7 +2,7 @@ import { getOpenDnDClient } from '../open_dnd_client'
 
 describe('Open Dnd Client', () => {
   it('should make calls', () => {
-    let client = getOpenDnDClient()
+    const client = getOpenDnDClient()
     expect(client.getInfo).not.toBeUndefined()
   })
 })

--- a/library/handlers/api/__tests__/parse_arguments.test.ts
+++ b/library/handlers/api/__tests__/parse_arguments.test.ts
@@ -2,7 +2,7 @@ import parse_arguments from '../parse_arguments'
 
 describe('parse arguments', () => {
   it('should handle empty', () => {
-    let result = parse_arguments()
+    const result = parse_arguments()
     expect(result).toHaveLength(0)
   })
 })

--- a/library/handlers/api/handler.ts
+++ b/library/handlers/api/handler.ts
@@ -4,9 +4,9 @@ import { getOpenDnDClient } from './open_dnd_client'
 import parseArguments from './parse_arguments'
 
 export default async (cmd: SlashCommand) => {
-  let [subcmd, parameter] = parseArguments(cmd.arguments)
-  let client = getOpenDnDClient()
-  let resp: AxiosResponse = await client.getInfo(subcmd, parameter)
+  const [subcmd, parameter] = parseArguments(cmd.arguments)
+  const client = getOpenDnDClient()
+  const resp: AxiosResponse = await client.getInfo(subcmd, parameter)
 
   return JSON.stringify(resp.data)
 }

--- a/library/handlers/api/open_dnd_client.ts
+++ b/library/handlers/api/open_dnd_client.ts
@@ -7,7 +7,7 @@ const dndApiItem = (section: string) => (item: string) =>
   `${dndApi(section)}/${item}`
 
 const getInfo = (section, params?: string) => {
-  let endpoint = !params
+  const endpoint = !params
     ? dndApi(section)
     : params.indexOf('?') != -1
     ? dndApiSearch(section)(params.replace('?', ''))

--- a/library/handlers/api/parse_arguments.ts
+++ b/library/handlers/api/parse_arguments.ts
@@ -5,7 +5,7 @@ export default (params?: string) => {
     return []
   }
 
-  let [, section, sectionArgs] = ARGS_TOKENIZER.exec(params)
+  const [, section, sectionArgs] = ARGS_TOKENIZER.exec(params)
 
   return [section, sectionArgs]
 }

--- a/library/parse_body.ts
+++ b/library/parse_body.ts
@@ -33,7 +33,7 @@ export default (body: string): SlashCommand => {
     return
   }
 
-  let [cmd, args] = tokenizeText(text)
+  const [cmd, args] = tokenizeText(text)
 
   if (!cmd) {
     return

--- a/library/slash_command.ts
+++ b/library/slash_command.ts
@@ -1,10 +1,10 @@
 import { Command } from './command'
 
 export type SlashCommand = {
-  command: Command
-  arguments: string
-  team_id: string
-  team_domain: string
-  user_id: string
-  user_name: string
+  command: Command;
+  arguments: string;
+  team_id: string;
+  team_domain: string;
+  user_id: string;
+  user_name: string;
 }

--- a/library/tokenize_text.ts
+++ b/library/tokenize_text.ts
@@ -6,7 +6,7 @@ export default (text: string): [Command, string?] => {
   if (!text || !text.length) {
     return [Command['NOOP']]
   }
-  let [, cmd, args] = COMMAND_TOKENIZER.exec(text)
+  const [, cmd, args] = COMMAND_TOKENIZER.exec(text)
 
   if (!cmd || !Command[cmd.toUpperCase()]) {
     return [Command['NOOP']]


### PR DESCRIPTION
autofixed issues, others remain see below

```
> eslint --fix --ext .js,.ts ./

E:\Projects\cautious-waffle\fixtures\slash_fixture.ts
   7:3  error  Identifier 'team_domain' is not in camel case  @typescript-eslint/camelcase
   8:3  error  Identifier 'team_id' is not in camel case      @typescript-eslint/camelcase
   9:3  error  Identifier 'user_id' is not in camel case      @typescript-eslint/camelcase
  10:3  error  Identifier 'user_name' is not in camel case    @typescript-eslint/camelcase

E:\Projects\cautious-waffle\handler.ts
   7:60  warning  '_context' is defined but never used  @typescript-eslint/no-unused-vars
  22:60  warning  '_ctx' is defined but never used      @typescript-eslint/no-unused-vars

E:\Projects\cautious-waffle\jest.config.js
  1:1  error  'module' is not defined  no-undef

E:\Projects\cautious-waffle\library\get_command_handler.ts
  5:16  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type

E:\Projects\cautious-waffle\library\handlers\api\handler.ts
  6:16  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type

E:\Projects\cautious-waffle\library\handlers\api\open_dnd_client.ts
   3:16  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type
   4:43  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type
   6:41  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type
   9:17  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type
  19:33  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type

E:\Projects\cautious-waffle\library\handlers\api\parse_arguments.ts
  3:16  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type

E:\Projects\cautious-waffle\library\handlers\api\__tests__\parse_arguments.test.ts
  1:8  error  Identifier 'parse_arguments' is not in camel case  @typescript-eslint/camelcase

E:\Projects\cautious-waffle\library\handlers\help.ts
  3:16  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type

E:\Projects\cautious-waffle\library\parse_body.ts
  16:5  error  Identifier 'team_id' is not in camel case      @typescript-eslint/camelcase
  17:5  error  Identifier 'team_domain' is not in camel case  @typescript-eslint/camelcase
  20:5  error  Identifier 'user_id' is not in camel case      @typescript-eslint/camelcase
  21:5  error  Identifier 'user_name' is not in camel case    @typescript-eslint/camelcase
  45:5  error  Identifier 'team_id' is not in camel case      @typescript-eslint/camelcase
  45:5  error  Identifier 'team_id' is not in camel case      @typescript-eslint/camelcase
  46:5  error  Identifier 'team_domain' is not in camel case  @typescript-eslint/camelcase
  46:5  error  Identifier 'team_domain' is not in camel case  @typescript-eslint/camelcase
  47:5  error  Identifier 'user_id' is not in camel case      @typescript-eslint/camelcase
  47:5  error  Identifier 'user_id' is not in camel case      @typescript-eslint/camelcase
  48:5  error  Identifier 'user_name' is not in camel case    @typescript-eslint/camelcase
  48:5  error  Identifier 'user_name' is not in camel case    @typescript-eslint/camelcase

E:\Projects\cautious-waffle\library\verify_signature.ts
   5:16  warning  Missing return type on function                         @typescript-eslint/explicit-function-return-type
  18:9   error    Identifier 'signature_basestring' is not in camel case  @typescript-eslint/camelcase
  23:9   error    Identifier 'derived_signature' is not in camel case     @typescript-eslint/camelcase
  24:9   error    Identifier 'slack_signature' is not in camel case       @typescript-eslint/camelcase
  26:10  error    Identifier 'derived_signature' is not in camel case     @typescript-eslint/camelcase
  26:32  error    Identifier 'slack_signature' is not in camel case       @typescript-eslint/camelcase
  28:10  error    Identifier 'derived_signature' is not in camel case     @typescript-eslint/camelcase
  28:31  error    Identifier 'slack_signature' is not in camel case       @typescript-eslint/camelcase

E:\Projects\cautious-waffle\library\__tests__\get_command_handler.test.ts
  1:8  error  Identifier 'get_command_handler' is not in camel case  @typescript-eslint/camelcase

E:\Projects\cautious-waffle\webpack.config.js
   1:14  error    Require statement not part of import statement                   @typescript-eslint/no-var-requires
   1:14  error    'require' is not defined                                         no-undef
   2:14  error    Require statement not part of import statement                   @typescript-eslint/no-var-requires
   2:14  error    'require' is not defined                                         no-undef
   3:23  error    Require statement not part of import statement                   @typescript-eslint/no-var-requires
   3:23  error    'require' is not defined                                         no-undef
   4:7   warning  'ForkTsCheckerWebpackPlugin' is assigned a value but never used  @typescript-eslint/no-unused-vars
   4:36  error    Require statement not part of import statement                   @typescript-eslint/no-var-requires
   4:36  error    'require' is not defined                                         no-undef
   6:1   error    'module' is not defined                                          no-undef
   7:12  error    '__dirname' is not defined                                       no-undef
  18:21  error    '__dirname' is not defined                                       no-undef
  31:26  error    '__dirname' is not defined                                       no-undef
  32:26  error    '__dirname' is not defined                                       no-undef
  33:26  error    '__dirname' is not defined                                       no-undef

✖ 53 problems (40 errors, 13 warnings)
```